### PR TITLE
Remove redundant definition of secp256k1 precomputed header causing build failure in tapyrus core

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,6 @@ include(GNUInstallDirs)
 # Add objects explicitly rather than linking to the object libs to keep them
 # from being exported.
 add_library(secp256k1 secp256k1.c)
-if(SECP256K1_ECMULT_STATIC_PRECOMPUTATION)
-  target_sources(secp256k1 PRIVATE ecmult_static_context.h)
-endif()
 
 target_include_directories(secp256k1 
     PUBLIC


### PR DESCRIPTION
The pre computation header is defined after the adding `src` directory in the cmake config file. SO the header is not found. this redundant definition is removed to fix the build.