### PR TITLE
Cmake build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ project(secp256k1
   HOMEPAGE_URL "https://github.com/chaintope/secp256k1"
   LANGUAGES C
 )
+
+# Prevent C++ headers from being included
+add_compile_definitions(SECP256K1_C_ONLY=1)
+
 enable_testing()
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
@@ -38,17 +42,14 @@ set(${PROJECT_NAME}_LIB_VERSION_AGE 0)
 #=============================
 # Language setup
 #=============================
-set(CMAKE_C_STANDARD 90)
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_EXTENSIONS OFF)
 
 #=============================
 # Configurable options
 #=============================
-option(BUILD_SHARED_LIBS "Build shared libraries." ON)
-option(SECP256K1_DISABLE_SHARED "Disable shared library. Overrides BUILD_SHARED_LIBS." OFF)
-if(SECP256K1_DISABLE_SHARED)
-  set(BUILD_SHARED_LIBS OFF)
-endif()
+option(BUILD_SHARED_LIBS "Build shared libraries." OFF)
+option(SECP256K1_DISABLE_SHARED "Disable shared library. Overrides BUILD_SHARED_LIBS." ON)
 
 option(SECP256K1_INSTALL "Enable installation." ${PROJECT_IS_TOP_LEVEL})
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -150,7 +150,7 @@ CFLAGS_FOR_BUILD += -Wall -Wextra -Wno-unused-function
 gen_context_OBJECTS = gen_context.o
 gen_context_BIN = gen_context$(BUILD_EXEEXT)
 gen_%.o: src/gen_%.c
-	$(CC_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(CFLAGS_FOR_BUILD) -c $< -o $@
+	$(CC_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) -I$(top_srcdir)/src $(CFLAGS_FOR_BUILD) -c $< -o $@
 
 $(gen_context_BIN): $(gen_context_OBJECTS)
 	$(CC_FOR_BUILD) $^ -o $@

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,6 @@ include(GNUInstallDirs)
 # Add objects explicitly rather than linking to the object libs to keep them
 # from being exported.
 add_library(secp256k1 secp256k1.c)
-if(SECP256K1_ECMULT_STATIC_PRECOMPUTATION)
-  target_sources(secp256k1 PRIVATE ecmult_static_context.h)
-endif()
 
 target_include_directories(secp256k1 
     PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,9 @@ include(GNUInstallDirs)
 # Add objects explicitly rather than linking to the object libs to keep them
 # from being exported.
 add_library(secp256k1 secp256k1.c)
+if(SECP256K1_ECMULT_STATIC_PRECOMPUTATION)
+  target_sources(secp256k1 PRIVATE ecmult_static_context.h)
+endif()
 
 target_include_directories(secp256k1 
     PUBLIC
@@ -51,6 +54,7 @@ endif()
 
 if(SECP256K1_ENABLE_MODULE_SCHNORR)
     target_compile_definitions(secp256k1 PRIVATE ENABLE_MODULE_SCHNORR=1)
+    target_sources(secp256k1 PRIVATE modules/schnorr/main_impl.h)
 endif()
 
 # We make sure __int128 is defined


### PR DESCRIPTION
make secp256k1 library create a static library by default to fix link errors in tapyrus core. 
port settings in the cmake build in generate gen_context to auto tools build